### PR TITLE
Fix interactive input requested in setup

### DIFF
--- a/vagrant/ubuntu/install-docker.sh
+++ b/vagrant/ubuntu/install-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export DEBIAN_FRONTEND=noninteractive 
 apt-get update \
     && apt-get install -y \
         apt-transport-https \


### PR DESCRIPTION
When docker-ce is installed it brings up an interactive prompt and in mac terminal it cannot be responded to and the setup as a result gets stuck.