### PR TITLE
Add comment about non-default number of hosts

### DIFF
--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -18,7 +18,9 @@ Run Vagrant up
 This does the below:
 
 - Deploys 5 VMs - 2 Master, 2 Worker and 1 Loadbalancer with the name 'kubernetes-ha-* '
-    > This is the default settings. This can be changed at the top of the Vagrant file
+    > This is the default settings. This can be changed at the top of the Vagrant file.
+    > If you choose to change these settings, please also update vagrant/ubuntu/vagrant/setup-hosts.sh
+    > to add the additional hosts to the /etc/hosts default before running "vagrant up".
 
 - Set's IP addresses in the range 192.168.5
 


### PR DESCRIPTION
I modified the Vagrantfile to create 3 masters and 3 workers, and noted that master-3 and worker-3 were not included in the /etc/hosts file.  So I've added a note about it in the appropriate doc.

Ideally, the /etc/hosts file would be generated based on Vagrant, but I've added a quick note for the time-being.