### PR TITLE
Fix deprecation in 1.16 for Deployment

### DIFF
--- a/deployments/coredns.yaml
+++ b/deployments/coredns.yaml
@@ -62,7 +62,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns


### PR DESCRIPTION
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/