### PR TITLE
Specify the correct host where to execute commands

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -16,7 +16,8 @@ Kubernetes uses a [special-purpose authorization mode](https://kubernetes.io/doc
 
 Generate a certificate and private key for one worker node:
 
-Worker1:
+On the **master** where you created the CA:
+
 
 ```
 master-1$ cat > openssl-worker-1.cnf <<EOF
@@ -55,6 +56,8 @@ LOADBALANCER_ADDRESS=192.168.5.30
 ```
 
 Generate a kubeconfig file for the first worker node:
+
+On the **master** used to create all configs:
 
 ```
 {


### PR DESCRIPTION
The first 2 steps must take place on the master used to generate the CA certificates (as it shows in the code example).