### PR TITLE
Disable RANDFILE to avoid missing '.rnd' file error

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -20,6 +20,9 @@ Create a CA certificate, then generate a Certificate Signing Request and use it 
 # Create private key for CA
 openssl genrsa -out ca.key 2048
 
+# Comment line starting with RANDFILE in /etc/ssl/openssl.cnf definition to avoid permission issues
+sudo sed -i '0,/RANDFILE/{s/RANDFILE/\#&/}' /etc/ssl/openssl.cnf
+
 # Create CSR using the private key
 openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA" -out ca.csr
 


### PR DESCRIPTION
```vagrant@master-1:~$ openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA" -out ca.csr
Can't load /home/vagrant/.rnd into RNG
140179099013568:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/home/vagrant/.rnd```