### PR TITLE
Fix issue Can't load /home/vagrant/.rnd into RNG

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -52,6 +52,7 @@ Generate the `admin` client certificate and private key:
 openssl genrsa -out admin.key 2048
 
 # Generate CSR for admin user. Note the OU.
+touch /home/vagrant/.rnd
 openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
 
 # Sign certificate for admin user using CA servers private key

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -21,6 +21,7 @@ Create a CA certificate, then generate a Certificate Signing Request and use it 
 openssl genrsa -out ca.key 2048
 
 # Create CSR using the private key
+touch /home/vagrant/.rnd
 openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA" -out ca.csr
 
 # Self sign the csr using its own private key
@@ -52,7 +53,6 @@ Generate the `admin` client certificate and private key:
 openssl genrsa -out admin.key 2048
 
 # Generate CSR for admin user. Note the OU.
-touch /home/vagrant/.rnd
 openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
 
 # Sign certificate for admin user using CA servers private key

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -45,10 +45,8 @@ Results:
 
 ```
 kube-proxy.kubeconfig
-
-
-Reference docs for kube-proxy [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
 ```
+Reference docs for kube-proxy [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
 
 ### The kube-controller-manager Kubernetes Configuration File
 


### PR DESCRIPTION
openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA" -out ca.csr
Running above command results in the following error if the /home/vagrant/.rnd file is not present

Can't load /home/vagrant/.rnd into RNG
140377325285824:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/home/vagrant/.rnd