### PR TITLE
need sudo permission to download with curl inside worker node

### DIFF
--- a/vagrant/ubuntu/install-docker-2.sh
+++ b/vagrant/ubuntu/install-docker-2.sh
@@ -1,3 +1,3 @@
 cd /tmp
-curl -fsSL https://get.docker.com -o get-docker.sh
+sudo curl -fsSL https://get.docker.com -o get-docker.sh
 sh /tmp/get-docker.sh


### PR DESCRIPTION
Noticed that the vagrant was not configuring the worker nodes correctly. Logged into the worker nodes and found that the issue is with curl download.
vagrant@worker-2:~$ cd /tmp/
vagrant@worker-2:/tmp$ curl -fsSL https://get.docker.com -o get-docker.sh
curl: (23) Failed writing body (0 != 13328)
vagrant@worker-2:/tmp$ 
I have noticed this and had to do this docker installation additionally to get the docker installed in the worker nodes. Since the docker was not installed automatically during vagrant installation, installation using the following script allow-bridge-nf-traffic.sh will also fail.  Solution is to add sudo during curl download.