### PR TITLE
Update End-To-End tests to use new version of Go

### DIFF
--- a/docs/16-e2e-tests.md
+++ b/docs/16-e2e-tests.md
@@ -3,9 +3,9 @@
 Install Go
 
 ```
-wget https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz
+wget https://golang.org/dl/go1.15.linux-amd64.tar.gz
 
-sudo tar -C /usr/local -xzf go1.12.1.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
 export GOPATH="/home/vagrant/go"
 export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ```

--- a/docs/16-e2e-tests.md
+++ b/docs/16-e2e-tests.md
@@ -3,7 +3,7 @@
 Install Go
 
 ```
-wget https://golang.org/dl/go1.15.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.15.linux-amd64.tar.gz
 
 sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
 export GOPATH="/home/vagrant/go"


### PR DESCRIPTION
The latest version of kubetest uses Go modules, so when trying to install kubetest, it might throw errors due to missing dependencies.

By using an updated go version, this is fixed.