### PR TITLE
Remove initial-cluster-token in etcd backup-restore guide

### DIFF
--- a/practice-questions-answers/cluster-maintenance/backup-etcd/etcd-backup-and-restore.md
+++ b/practice-questions-answers/cluster-maintenance/backup-etcd/etcd-backup-and-restore.md
@@ -45,25 +45,18 @@ ETCDCTL_API=3 etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/etc/kuberne
      --cert=/etc/kubernetes/pki/etcd/server.crt --key=/etc/kubernetes/pki/etcd/server.key \
      --data-dir /var/lib/etcd-from-backup \
      --initial-cluster=master=https://127.0.0.1:2380 \
-     --initial-cluster-token=etcd-cluster-1 \
      --initial-advertise-peer-urls=https://127.0.0.1:2380 \
      snapshot restore /tmp/snapshot-pre-boot.db
 ```
 
 # 4. Modify /etc/kubernetes/manifests/etcd.yaml
 
-Update ETCD POD to use the new data directory and cluster token by modifying the pod definition file at `/etc/kubernetes/manifests/etcd.yaml`. When this file is updated, the ETCD pod is automatically re-created as this is a static pod placed under the `/etc/kubernetes/manifests` directory.
+Update ETCD POD to use the new data directory by modifying the pod definition file at `/etc/kubernetes/manifests/etcd.yaml`. When this file is updated, the ETCD pod is automatically re-created as this is a static pod placed under the `/etc/kubernetes/manifests` directory.
 
 Update --data-dir to use new target location
 
 ```
 --data-dir=/var/lib/etcd-from-backup
-```
-
-Update new initial-cluster-token to specify new cluster
-
-```
---initial-cluster-token=etcd-cluster-1
 ```
 
 Update volumes and volume mounts to point to new path


### PR DESCRIPTION
Hello Mannambeth. I am taking your cka class and I appreciate you giving such a good lecture.
I referred the document to solve etcd restore practice, and found an option which is not essentially required.

Changing `--initial-cluster-token` parameter value in restore is required when the token **already exists.**
In kubernetes-the-hard-way, `--initial-cluster-token` is set initially (as value etcd-cluster-0), so overriding this value is required.

But, if k8s is installed by kubeadm, this value is not set.
In the practice, the parameter was not configured before restoring.
It is safe to leave the cluster as it is, by not adding new token.

In addition, this documentation is **the answer of etcd backup and restore practice in cka course.**
Because `initial-cluster-token` does not have ever been mentioned in the course, this option only increases the complexity of the answer.

Thank you.