### PR TITLE
Fix the error invalid value api/all=

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -99,7 +99,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --kubelet-client-certificate=/var/lib/kubernetes/kube-apiserver.crt \\
   --kubelet-client-key=/var/lib/kubernetes/kube-apiserver.key \\
   --kubelet-https=true \\
-  --runtime-config=api/all \\
+  --runtime-config=api/all=true \\
   --service-account-key-file=/var/lib/kubernetes/service-account.crt \\
   --service-cluster-ip-range=10.96.0.0/24 \\
   --service-node-port-range=30000-32767 \\


### PR DESCRIPTION
This PR fixes the following error:
## Error Details
```
kube-apiserver[41463]: Error: invalid value api/all=
```

## Kubernetes
- Version: v1.19.0
- Binaries: https://dl.k8s.io/v1.19.0/kubernetes-server-linux-amd64.tar.gz

## OS
```
# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.1 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.1 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

## Documentation
https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
>--runtime-config mapStringString
A set of key=value pairs that enable or disable built-in APIs. Supported options are:
...
api/all=true\|false controls all API versions
...