### PR TITLE
Re-add "Running Commands in Parallel with tmux"

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -27,3 +27,13 @@ Download and Install [Vagrant](https://www.vagrantup.com/) on your platform.
 - Linux
 - macOS
 - Arch Linux
+
+## Running Commands in Parallel with tmux
+
+[tmux](https://github.com/tmux/tmux/wiki) can be used to run commands on multiple compute instances at the same time. Labs in this tutorial may require running the same commands across multiple compute instances, in those cases consider using tmux and splitting a window into multiple panes with synchronize-panes enabled to speed up the provisioning process.
+
+> The use of tmux is optional and not required to complete this tutorial.
+
+![tmux screenshot](images/tmux-screenshot.png)
+
+> Enable synchronize-panes by pressing `ctrl+b` followed by `shift+:`. Next type `set synchronize-panes on` at the prompt. To disable synchronization: `set synchronize-panes off`.


### PR DESCRIPTION
This content is referred to by docs/07-bootstrapping-etcd.md.

Another fix would be to just delete the dangling link on the bootstrapping-etcd page.