### PR TITLE
Fix pluralization in the worker bootstrap lab

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -1,6 +1,6 @@
-# Bootstrapping the Kubernetes Worker Nodes
+# Bootstrapping the First Kubernetes Worker Node
 
-In this lab you will bootstrap 2 Kubernetes worker nodes. We already have [Docker](https://www.docker.com) installed on these nodes.
+In this lab you will bootstrap the first worker node. We already have [Docker](https://www.docker.com) installed.
 
 We will now install the kubernetes components
 - [kubelet](https://kubernetes.io/docs/admin/kubelet)


### PR DESCRIPTION
This lab sets up `worker-1` by hand. The next lab sets up the rest.