### PR TITLE
Update 06-data-encryption-keys.md

### DIFF
--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -40,14 +40,6 @@ for instance in master-1 master-2; do
 done
 ```
 
-Move `encryption-config.yaml` encryption config file to appropriate directory.
-
-```
-for instance in master-1 master-2; do
-  ssh ${instance} sudo mv encryption-config.yaml /var/lib/kubernetes/
-done
-```
-
 Reference: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#encrypting-your-data
 
 Next: [Bootstrapping the etcd Cluster](07-bootstrapping-etcd.md)


### PR DESCRIPTION
The movement of encryption-config.yaml shouldn't be done here for two reasons:

1. /var/lib/kubernetes doesn't exist yet.
2. The copying is being done at https://github.com/mmumshad/kubernetes-the-hard-way/blob/master/docs/08-bootstrapping-kubernetes-controllers.md#configure-the-kubernetes-api-server

Kindly review.

Fixes #218 