### PR TITLE
Update 06-data-encryption-keys.md

### DIFF
--- a/docs/06-data-encryption-keys.md
+++ b/docs/06-data-encryption-keys.md
@@ -44,7 +44,8 @@ Move `encryption-config.yaml` encryption config file to appropriate directory.
 
 ```
 for instance in master-1 master-2; do
-  ssh ${instance} sudo mv encryption-config.yaml /var/lib/kubernetes/
+  ssh ${instance} sudo mkdir -p /var/lib/kubernetes/
+  ssh ${instance} sudo mv ~/encryption-config.yaml /var/lib/kubernetes/
 done
 ```
 


### PR DESCRIPTION
Under the section "Move `encryption-config.yaml` encryption config file to appropriate directory.",
At this stage there is no "/var/lib/kubernetes/" directory. At first, the directory needs to be created before moving the encryption-config.yaml file.