### PR TITLE
Update 08-bootstrapping-kubernetes-controllers.md

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -50,7 +50,7 @@ Install the Kubernetes binaries:
   sudo cp ca.crt ca.key kube-apiserver.crt kube-apiserver.key \
     service-account.key service-account.crt \
     etcd-server.key etcd-server.crt \
-    encryption-config.yaml /var/lib/kubernetes/
+    /var/lib/kubernetes/
 }
 ```
 


### PR DESCRIPTION
encryption-config.yaml cannot be copied over /var/lib/kubernetes because it was moved during the step 6. So it doesn't exist anymore in the home folder.
```
vagrant@master-1:~$ {                                               
>   sudo mkdir -p /var/lib/kubernetes/                              
>                                                                   
>   sudo cp ca.crt ca.key kube-apiserver.crt kube-apiserver.key \   
>     service-account.key service-account.crt \                     
>     etcd-server.key etcd-server.crt \                             
>     encryption-config.yaml /var/lib/kubernetes/                   
> }                                                                 
cp: cannot stat 'encryption-config.yaml': No such file or directory 
```