### PR TITLE
fix Kernel Panic while provisioning

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -81,7 +81,7 @@ Vagrant.configure("2") do |config|
     node.vm.provider "virtualbox" do |vb|
         vb.name = "kubernetes-ha-lb"
         vb.memory = 512
-        vb.cpus = 1
+        vb.cpus = 2
     end
     node.vm.hostname = "loadbalancer"
     node.vm.network :private_network, ip: IP_NW + "#{LB_IP_START}"
@@ -101,7 +101,7 @@ Vagrant.configure("2") do |config|
         node.vm.provider "virtualbox" do |vb|
             vb.name = "kubernetes-ha-worker-#{i}"
             vb.memory = 512
-            vb.cpus = 1
+            vb.cpus = 2
         end
         node.vm.hostname = "worker-#{i}"
         node.vm.network :private_network, ip: IP_NW + "#{NODE_IP_START + i}"


### PR DESCRIPTION
Update Load Balancer and worker Node with higher value vb.cpus to be 2 to fix "Kernel Panic not syncing: Attempted to kill the idle task!" while provisioning