### PR TITLE
Update coredns `ClusterRole`

### DIFF
--- a/deployments/coredns.yaml
+++ b/deployments/coredns.yaml
@@ -21,6 +21,13 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fix #295 
After granting `ClusterRole` with `endpointslices `, it works fine.
```
.:53
[INFO] plugin/reload: Running configuration SHA512 = 591cf328cccc12bc490481273e738df59329c62c0b729d94e8b61db9961c2fa5f046dd37f1cf888b953814040d180f52594972691cd6ff41be96639138a43908
CoreDNS-1.9.4
linux/amd64, go1.19.1, 1f0a41a
```