### PR TITLE
updates for CNI dependencies on worker nodes with weave

### DIFF
--- a/docs/13-configure-pod-networking.md
+++ b/docs/13-configure-pod-networking.md
@@ -4,6 +4,21 @@ Container Network Interface (CNI) is a standard interface for managing IP networ
 
 We chose to use CNI - [weave](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/) as our networking option.
 
+# Prerequisite on Worker Nodes
+
+Install cni support binaries on worker nodes for weave-net. 
+
+[//]: # (host:worker-1-worker-2)
+
+On `worker-1` & `worker-2`
+
+```bash
+{
+  sudo mkdir -p /opt/cni/bin
+  sudo wget https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-amd64-v0.9.0.tgz -P /opt/cni/bin/
+  sudo tar -xzvf /opt/cni/bin/cni-plugins-linux-amd64-v0.9.0.tgz -C /opt/cni/bin/
+}
+```
 
 ### Deploy Weave Network
 


### PR DESCRIPTION
the weave cni is not taking care of the loopback, which is needed on pod deployments. This was preventing all next pods, even the coredns pods to comeup. event logs from coredns pod
Events:
  Type     Reason                  Age                   From               Message
  ----     ------                  ----                  ----               -------
  Normal   Scheduled               14m                   default-scheduler  Successfully assigned kube-system/coredns-6cc4b9868d-mhzkf to worker-1
  Warning  FailedCreatePodSandBox  14m                   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "0dbe54e1d0525e2a6af9fb7e7fb2d3ae8576a376678e3d07d270c685a651d7d0": failed to find plugin "loopback" in path [/opt/cni/bin]

This is fixed by downloading the plugins from[https://github.com/containernetworking/plugins/releases/tag/v0.9.0], to directory /opt/cni/bin/ and then provisioning the weave daemon-sets.

This was not available in stackoverflow or other places as well, Hope it helps,