### PR TITLE
Sync readme with script's output

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -359,12 +359,6 @@ Run the following, and select option 1 to check all required certificates were g
 ./cert_verify.sh
 ```
 
-> Expected output
-
-```
-PKI generated correctly!
-```
-
 If there are any errors, please review above steps and then re-verify
 
 ## Distribute the Certificates


### PR DESCRIPTION
cert_verify.sh doesn't report final message PKI generated correctly! but it's clear from the readme that we need to verify if we see error.