### PR TITLE
Adjust markdown formatting

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -1,13 +1,13 @@
 # Prerequisites
 
-## VM Hardware Requirements
+## VM hardware requirements
 
-8 GB of RAM (Preferably 16 GB)
-50 GB Disk space
+8 GB of RAM (preferably 16 GB)
+50 GB disk space
 
-## Virtual Box
+## VirtualBox
 
-Download and Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) on any one of the supported platforms:
+Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) on any one of the supported platforms:
 
  - Windows hosts
  - OS X hosts (x86 only, not Apple Silicon M-series)
@@ -19,7 +19,7 @@ Download and Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) on 
 Once VirtualBox is installed you may chose to deploy virtual machines manually on it.
 Vagrant provides an easier way to deploy multiple virtual machines on VirtualBox more consistently.
 
-Download and Install [Vagrant](https://www.vagrantup.com/) on your platform.
+Download and install [Vagrant](https://www.vagrantup.com/) on your platform.
 
 - Windows
 - Debian
@@ -30,7 +30,7 @@ Download and Install [Vagrant](https://www.vagrantup.com/) on your platform.
 This tutorial assumes that you have also installed Vagrant.
 
 
-## Lab Defaults
+## Lab defaults
 
 The labs have been configured with the following networking defaults. If you change any of these after you have deployed any of the lab, you'll need to completely reset it and start again from the beginning:
 
@@ -41,9 +41,9 @@ vagrant up
 
 If you do change any of these, **please consider that a personal preference and don't submit a PR for it**.
 
-### Virtual Machine Network
+### Virtual machine network
 
-The network used by the Virtual Box virtual machines is `192.168.56.0/24`.
+The network used by the VirtualBox virtual machines is `192.168.56.0/24`.
 
 To change this, edit the [Vagrantfile](../vagrant/Vagrantfile) in your cloned copy (do not edit directly in github), and set the new value for the network prefix at line 9. This should not overlap any of the other network settings.
 
@@ -51,7 +51,7 @@ Note that you do not need to edit any of the other scripts to make the above cha
 
 It is *recommended* that you leave the pod and service networks with the following defaults. If you change them then you will also need to edit one or both of the CoreDNS and Weave networking manifests to accommodate your change.
 
-### Pod Network
+### Pod network
 
 The network used to assign IP addresses to pods is `10.244.0.0/16`.
 
@@ -59,7 +59,7 @@ To change this, open all the `.md` files in the [docs](../docs/) directory in yo
 `POD_CIDR=10.244.0.0/16`<br>
 with the new CDIR range.  This should not overlap any of the other network settings.
 
-### Service Network
+### Service network
 
 The network used to assign IP addresses to Cluster IP services is `10.96.0.0/16`.
 
@@ -69,7 +69,7 @@ with the new CDIR range.  This should not overlap any of the other network setti
 
 Additionally edit line 164 of [coredns.yaml](../deployments/coredns.yaml) to set the new DNS service address (should still end with `.10`)
 
-## Running Commands in Parallel with tmux
+## Running commands in parallel with tmux
 
 [tmux](https://github.com/tmux/tmux/wiki) can be used to run commands on multiple compute instances at the same time. Labs in this tutorial may require running the same commands across multiple compute instances, in those cases consider using tmux and splitting a window into multiple panes with synchronize-panes enabled to speed up the provisioning process.
 

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -2,8 +2,8 @@
 
 ## VM hardware requirements
 
-8 GB of RAM (preferably 16 GB)
-50 GB disk space
+- 8 GB of RAM (preferably 16 GB)
+- 50 GB disk space
 
 ## VirtualBox
 

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -79,4 +79,4 @@ Additionally edit line 164 of [coredns.yaml](../deployments/coredns.yaml) to set
 
 > Enable synchronize-panes by pressing `CTRL+B` followed by `"` to split the window into two panes. In each pane (selectable with mouse), ssh to the host(s) you will be working with.</br>Next type `CTRL+X` at the prompt to begin sync. In sync mode, the dividing line between panes will be red. Everything you type or paste in one pane will be echoed in the other.<br>To disable synchronization type `CTRL+X` again.</br></br>Note that the `CTRL-X` key binding is provided by a `.tmux.conf` loaded onto the VM by the vagrant provisioner.
 
-Next: [Compute Resources](02-compute-resources.md)
+Next: [Compute resources](02-compute-resources.md)

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-## VM hardware requirements
+## VM Hardware Requirements
 
 - 8 GB of RAM (preferably 16 GB)
 - 50 GB disk space
@@ -30,7 +30,7 @@ Download and install [Vagrant](https://www.vagrantup.com/) on your platform.
 This tutorial assumes that you have also installed Vagrant.
 
 
-## Lab defaults
+## Lab Defaults
 
 The labs have been configured with the following networking defaults. If you change any of these after you have deployed any of the lab, you'll need to completely reset it and start again from the beginning:
 
@@ -41,7 +41,7 @@ vagrant up
 
 If you do change any of these, **please consider that a personal preference and don't submit a PR for it**.
 
-### Virtual machine network
+### Virtual Machine Network
 
 The network used by the VirtualBox virtual machines is `192.168.56.0/24`.
 
@@ -51,7 +51,7 @@ Note that you do not need to edit any of the other scripts to make the above cha
 
 It is *recommended* that you leave the pod and service networks with the following defaults. If you change them then you will also need to edit one or both of the CoreDNS and Weave networking manifests to accommodate your change.
 
-### Pod network
+### Pod Network
 
 The network used to assign IP addresses to pods is `10.244.0.0/16`.
 
@@ -59,7 +59,7 @@ To change this, open all the `.md` files in the [docs](../docs/) directory in yo
 `POD_CIDR=10.244.0.0/16`<br>
 with the new CDIR range.  This should not overlap any of the other network settings.
 
-### Service network
+### Service Network
 
 The network used to assign IP addresses to Cluster IP services is `10.96.0.0/16`.
 
@@ -69,7 +69,7 @@ with the new CDIR range.  This should not overlap any of the other network setti
 
 Additionally edit line 164 of [coredns.yaml](../deployments/coredns.yaml) to set the new DNS service address (should still end with `.10`)
 
-## Running commands in parallel with tmux
+## Running Commands in Parallel with tmux
 
 [tmux](https://github.com/tmux/tmux/wiki) can be used to run commands on multiple compute instances at the same time. Labs in this tutorial may require running the same commands across multiple compute instances, in those cases consider using tmux and splitting a window into multiple panes with synchronize-panes enabled to speed up the provisioning process.
 
@@ -79,4 +79,4 @@ Additionally edit line 164 of [coredns.yaml](../deployments/coredns.yaml) to set
 
 > Enable synchronize-panes by pressing `CTRL+B` followed by `"` to split the window into two panes. In each pane (selectable with mouse), ssh to the host(s) you will be working with.</br>Next type `CTRL+X` at the prompt to begin sync. In sync mode, the dividing line between panes will be red. Everything you type or paste in one pane will be echoed in the other.<br>To disable synchronization type `CTRL+X` again.</br></br>Note that the `CTRL-X` key binding is provided by a `.tmux.conf` loaded onto the VM by the vagrant provisioner.
 
-Next: [Compute resources](02-compute-resources.md)
+Next: [Compute Resources](02-compute-resources.md)

--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -1,14 +1,14 @@
-# Provisioning Compute Resources
+# Provisioning compute resources
 
-Note: You must have VirtualBox and Vagrant configured at this point
+Note: You must have VirtualBox and Vagrant configured at this point.
 
-Download this github repository and cd into the vagrant folder
+Download this github repository and cd into the vagrant folder:
 
 ```bash
 git clone https://github.com/mmumshad/kubernetes-the-hard-way.git
 ```
 
-CD into vagrant directory
+CD into vagrant directory:
 
 ```bash
 cd kubernetes-the-hard-way/vagrant
@@ -18,7 +18,7 @@ The `Vagrantfile` is configured to assume you have at least an 8 core CPU which 
 
 This will not work if you have less than 8GB of RAM.
 
-Run Vagrant up
+Run Vagrant up:
 
 ```bash
 vagrant up
@@ -29,10 +29,10 @@ This does the below:
 
 - Deploys 5 VMs - 2 Master, 2 Worker and 1 Loadbalancer with the name 'kubernetes-ha-* '
     > This is the default settings. This can be changed at the top of the Vagrant file.
-    > If you choose to change these settings, please also update vagrant/ubuntu/vagrant/setup-hosts.sh
-    > to add the additional hosts to the /etc/hosts default before running "vagrant up".
+    > If you choose to change these settings, please also update `vagrant/ubuntu/vagrant/setup-hosts.sh`
+    > to add the additional hosts to the `/etc/hosts` default before running `vagrant up`.
 
-- Set's IP addresses in the range 192.168.56
+- Set's IP addresses in the range `192.168.56.x`
 
     | VM            |  VM Name               | Purpose       | IP            | Forwarded Port   | RAM  |
     | ------------  | ---------------------- |:-------------:| -------------:| ----------------:|-----:|
@@ -60,28 +60,28 @@ There are two ways to SSH into the nodes:
   From the directory you ran the `vagrant up` command, run `vagrant ssh <vm>` for example `vagrant ssh master-1`.
   > Note: Use VM field from the above table and not the VM name itself.
 
-### 2. SSH Using SSH Client Tools
+### 2. SSH using SSH client tools
 
-Use your favourite SSH Terminal tool (putty).
+Use your favourite SSH terminal tool (putty).
 
-Use the above IP addresses. Username and password based SSH is disabled by default.
-Vagrant generates a private key for each of these VMs. It is placed under the .vagrant folder (in the directory you ran the `vagrant up` command from) at the below path for each VM:
+Use the above IP addresses. Username and password-based SSH is disabled by default.
 
-**Private Key Path:** `.vagrant/machines/<machine name>/virtualbox/private_key`
+Vagrant generates a private key for each of these VMs. It is placed under the `.vagrant` folder (in the directory you ran the `vagrant up` command from) at the below path for each VM:
 
-**Username/Password:** `vagrant/vagrant`
+- **Private key path**: `.vagrant/machines/<machine name>/virtualbox/private_key`
+- **Username/password**: `vagrant/vagrant`
 
 
-## Verify Environment
+## Verify environment
 
-- Ensure all VMs are up
-- Ensure VMs are assigned the above IP addresses
-- Ensure you can SSH into these VMs using the IP and private keys, or `vagrant ssh`
-- Ensure the VMs can ping each other
+- Ensure all VMs are up.
+- Ensure VMs are assigned the above IP addresses.
+- Ensure you can SSH into these VMs using the IP and private keys, or `vagrant ssh`.
+- Ensure the VMs can ping each other.
 
-## Troubleshooting Tips
+## Troubleshooting tips
 
-### Failed Provisioning
+### Failed provisioning
 
 If any of the VMs failed to provision, or is not configured correct, delete the VM using the command:
 
@@ -121,7 +121,7 @@ This will most likely happen at "Waiting for machine to reboot"
 1. Destroy the VM that got stuck: `vagrant destroy <vm>`
 1. Re-provision. It will pick up where it left off: `vagrant up`
 
-# Pausing the Environment
+# Pausing the environment
 
 You do not need to complete the entire lab in one session. You may shut down and resume the environment as follows, if you need to power off your computer.
 

--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -57,7 +57,7 @@ There are two ways to SSH into the nodes:
 
 ### 1. SSH using Vagrant
 
-  From the directory you ran the `vagrant up` command, run `vagrant ssh <vm>` for example `vagrant ssh master-1`.
+  From the directory you ran the `vagrant up` command, run `vagrant ssh \<vm\>` for example `vagrant ssh master-1`.
   > Note: Use VM field from the above table and not the VM name itself.
 
 ### 2. SSH using SSH client tools
@@ -68,7 +68,7 @@ Use the above IP addresses. Username and password-based SSH is disabled by defau
 
 Vagrant generates a private key for each of these VMs. It is placed under the `.vagrant` folder (in the directory you ran the `vagrant up` command from) at the below path for each VM:
 
-- **Private key path**: `.vagrant/machines/<machine name>/virtualbox/private_key`
+- **Private key path**: `.vagrant/machines/\<machine name\>/virtualbox/private_key`
 - **Username/password**: `vagrant/vagrant`
 
 
@@ -86,7 +86,7 @@ Vagrant generates a private key for each of these VMs. It is placed under the `.
 If any of the VMs failed to provision, or is not configured correct, delete the VM using the command:
 
 ```bash
-vagrant destroy <vm>
+vagrant destroy \<vm\>
 ```
 
 Then re-provision. Only the missing VMs will be re-provisioned
@@ -108,7 +108,7 @@ In such cases delete the VM, then delete the VM folder and then re-provision, e.
 
 ```bash
 vagrant destroy worker-2
-rmdir "<path-to-vm-folder>\kubernetes-ha-worker-2
+rmdir "\<path-to-vm-folder\>\kubernetes-ha-worker-2
 vagrant up
 ```
 
@@ -118,7 +118,7 @@ This will most likely happen at "Waiting for machine to reboot"
 
 1. Hit `CTRL+C`
 1. Kill any running `ruby` process, or Vagrant will complain.
-1. Destroy the VM that got stuck: `vagrant destroy <vm>`
+1. Destroy the VM that got stuck: `vagrant destroy \<vm\>`
 1. Re-provision. It will pick up where it left off: `vagrant up`
 
 # Pausing the environment
@@ -127,13 +127,13 @@ You do not need to complete the entire lab in one session. You may shut down and
 
 To shut down. This will gracefully shut down all the VMs in the reverse order to which they were started:
 
-```
+```bash
 vagrant halt
 ```
 
 To power on again:
 
-```
+```bash
 vagrant up
 ```
 

--- a/docs/02-compute-resources.md
+++ b/docs/02-compute-resources.md
@@ -1,4 +1,4 @@
-# Provisioning compute resources
+# Provisioning Compute Resources
 
 Note: You must have VirtualBox and Vagrant configured at this point.
 
@@ -60,7 +60,7 @@ There are two ways to SSH into the nodes:
   From the directory you ran the `vagrant up` command, run `vagrant ssh \<vm\>` for example `vagrant ssh master-1`.
   > Note: Use VM field from the above table and not the VM name itself.
 
-### 2. SSH using SSH client tools
+### 2. SSH Using SSH Client Tools
 
 Use your favourite SSH terminal tool (putty).
 
@@ -72,16 +72,16 @@ Vagrant generates a private key for each of these VMs. It is placed under the `.
 - **Username/password**: `vagrant/vagrant`
 
 
-## Verify environment
+## Verify Environment
 
 - Ensure all VMs are up.
 - Ensure VMs are assigned the above IP addresses.
 - Ensure you can SSH into these VMs using the IP and private keys, or `vagrant ssh`.
 - Ensure the VMs can ping each other.
 
-## Troubleshooting tips
+## Troubleshooting Tips
 
-### Failed provisioning
+### Failed Provisioning
 
 If any of the VMs failed to provision, or is not configured correct, delete the VM using the command:
 
@@ -121,7 +121,7 @@ This will most likely happen at "Waiting for machine to reboot"
 1. Destroy the VM that got stuck: `vagrant destroy \<vm\>`
 1. Re-provision. It will pick up where it left off: `vagrant up`
 
-# Pausing the environment
+# Pausing the Environment
 
 You do not need to complete the entire lab in one session. You may shut down and resume the environment as follows, if you need to power off your computer.
 

--- a/docs/03-client-tools.md
+++ b/docs/03-client-tools.md
@@ -1,6 +1,6 @@
-# Installing the Client Tools
+# Installing the client tools
 
-First identify a system from where you will perform administrative tasks, such as creating certificates, kubeconfig files and distributing them to the different VMs.
+First identify a system from where you will perform administrative tasks, such as creating certificates, `kubeconfig` files and distributing them to the different VMs.
 
 If you are on a Linux laptop, then your laptop could be this system. In my case I chose the `master-1` node to perform administrative tasks. Whichever system you chose make sure that system is able to access all the provisioned VMs through SSH to copy files over.
 
@@ -8,7 +8,7 @@ If you are on a Linux laptop, then your laptop could be this system. In my case 
 
 Here we create an SSH key pair for the `vagrant` user who we are logged in as. We will copy the public key of this pair to the other master and both workers to permit us to use password-less SSH (and SCP) go get from `master-1` to these other nodes in the context of the `vagrant` user which exists on all nodes.
 
-Generate Key Pair on `master-1` node
+Generate SSH key pair on `master-1` node:
 
 [//]: # (host:master-1)
 
@@ -18,7 +18,7 @@ ssh-keygen
 
 Leave all settings to default by pressing `ENTER` at any prompt.
 
-Add this key to the local authorized_keys (`master-1`) as in some commands we scp to ourself.
+Add this key to the local `authorized_keys` (`master-1`) as in some commands we `scp` to ourself.
 
 ```bash
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -50,7 +50,7 @@ The [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) command li
 
 Reference: [https://kubernetes.io/docs/tasks/tools/install-kubectl/](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-We will be using kubectl early on to generate kubeconfig files for the controlplane components.
+We will be using `kubectl` early on to generate `kubeconfig` files for the controlplane components.
 
 ### Linux
 
@@ -68,7 +68,7 @@ Verify `kubectl` is installed:
 kubectl version -o yaml
 ```
 
-> output will be similar to this, although versions may be newer
+output will be similar to this, although versions may be newer:
 
 ```
 kubectl version -o yaml
@@ -89,5 +89,5 @@ The connection to the server localhost:8080 was refused - did you specify the ri
 
 Don't worry about the error at the end as it is expected. We have not set anything up yet!
 
-Prev: [Compute Resources](02-compute-resources.md)<br>
-Next: [Certificate Authority](04-certificate-authority.md)
+Prev: [Compute resources](02-compute-resources.md)<br>
+Next: [Certificate authority](04-certificate-authority.md)

--- a/docs/03-client-tools.md
+++ b/docs/03-client-tools.md
@@ -1,4 +1,4 @@
-# Installing the client tools
+# Installing the Client Tools
 
 First identify a system from where you will perform administrative tasks, such as creating certificates, `kubeconfig` files and distributing them to the different VMs.
 
@@ -89,5 +89,5 @@ The connection to the server localhost:8080 was refused - did you specify the ri
 
 Don't worry about the error at the end as it is expected. We have not set anything up yet!
 
-Prev: [Compute resources](02-compute-resources.md)<br>
-Next: [Certificate authority](04-certificate-authority.md)
+Prev: [Compute Resources](02-compute-resources.md)<br>
+Next: [Certificate Authority](04-certificate-authority.md)

--- a/docs/03-client-tools.md
+++ b/docs/03-client-tools.md
@@ -46,7 +46,7 @@ and check to make sure that only the key(s) you wanted were added.
 
 ## Install kubectl
 
-The [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl). command line utility is used to interact with the Kubernetes API Server. Download and install `kubectl` from the official release binaries:
+The [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) command line utility is used to interact with the Kubernetes API Server. Download and install `kubectl` from the official release binaries:
 
 Reference: [https://kubernetes.io/docs/tasks/tools/install-kubectl/](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -53,19 +53,17 @@ The output should look like this. If you changed any of the defaults mentioned i
 
 Create a CA certificate, then generate a Certificate Signing Request and use it to create a private key:
 
-
 ```bash
-{
-  # Create private key for CA
-  openssl genrsa -out ca.key 2048
+# Create private key for CA
+openssl genrsa -out ca.key 2048
 
-  # Create CSR using the private key
-  openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA/O=Kubernetes" -out ca.csr
+# Create CSR using the private key
+openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA/O=Kubernetes" -out ca.csr
 
-  # Self sign the csr using its own private key
-  openssl x509 -req -in ca.csr -signkey ca.key -CAcreateserial  -out ca.crt -days 1000
-}
+# Self sign the csr using its own private key
+openssl x509 -req -in ca.csr -signkey ca.key -CAcreateserial -out ca.crt -days 1000
 ```
+
 Results:
 
 ```
@@ -75,7 +73,7 @@ ca.key
 
 Reference : https://kubernetes.io/docs/tasks/administer-cluster/certificates/#openssl
 
-The `ca.crt` is the Kubernetes Certificate Authority certificate and ca.key is the Kubernetes Certificate Authority private key.
+The `ca.crt` is the Kubernetes Certificate Authority certificate and `ca.key` is the Kubernetes Certificate Authority private key.
 You will use the `ca.crt` file in many places, so it will be copied to many places.
 
 The `ca.key` is used by the CA for signing certificates. And it should be securely stored. In this case our master node(s) is our CA server as well, so we will store it on master node(s). There is no need to copy this file elsewhere.
@@ -89,16 +87,14 @@ In this section you will generate client and server certificates for each Kubern
 Generate the `admin` client certificate and private key:
 
 ```bash
-{
-  # Generate private key for admin user
-  openssl genrsa -out admin.key 2048
+# Generate private key for admin user
+openssl genrsa -out admin.key 2048
 
-  # Generate CSR for admin user. Note the OU.
-  openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
+# Generate CSR for admin user. Note the OU.
+openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
 
-  # Sign certificate for admin user using CA servers private key
-  openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial  -out admin.crt -days 1000
-}
+# Sign certificate for admin user using CA servers private key
+openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out admin.crt -days 1000
 ```
 
 Note that the admin user is part of the **system:masters** group. This is how we are able to perform any administrative operations on Kubernetes cluster using `kubectl` utility.
@@ -122,14 +118,13 @@ For now let's just focus on the control plane components.
 Generate the `kube-controller-manager` client certificate and private key:
 
 ```bash
-{
-  openssl genrsa -out kube-controller-manager.key 2048
+openssl genrsa -out kube-controller-manager.key 2048
 
-  openssl req -new -key kube-controller-manager.key \
-    -subj "/CN=system:kube-controller-manager/O=system:kube-controller-manager" -out kube-controller-manager.csr
+openssl req -new -key kube-controller-manager.key \
+  -subj "/CN=system:kube-controller-manager/O=system:kube-controller-manager" -out kube-controller-manager.csr
 
-  openssl x509 -req -in kube-controller-manager.csr \
-    -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-controller-manager.crt -days 1000
+openssl x509 -req -in kube-controller-manager.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-controller-manager.crt -days 1000
 }
 ```
 
@@ -141,21 +136,19 @@ kube-controller-manager.crt
 ```
 
 
-### The Kube Proxy Client Certificate
+### The Kube Proxy client certificate
 
 Generate the `kube-proxy` client certificate and private key:
 
 
 ```bash
-{
-  openssl genrsa -out kube-proxy.key 2048
+openssl genrsa -out kube-proxy.key 2048
 
-  openssl req -new -key kube-proxy.key \
-    -subj "/CN=system:kube-proxy/O=system:node-proxier" -out kube-proxy.csr
+openssl req -new -key kube-proxy.key \
+  -subj "/CN=system:kube-proxy/O=system:node-proxier" -out kube-proxy.csr
 
-  openssl x509 -req -in kube-proxy.csr \
-    -CA ca.crt -CAkey ca.key -CAcreateserial  -out kube-proxy.crt -days 1000
-}
+openssl x509 -req -in kube-proxy.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-proxy.crt -days 1000
 ```
 
 Results:
@@ -165,21 +158,19 @@ kube-proxy.key
 kube-proxy.crt
 ```
 
-### The Scheduler Client Certificate
+### The Scheduler client certificate
 
 Generate the `kube-scheduler` client certificate and private key:
 
 
 
 ```bash
-{
-  openssl genrsa -out kube-scheduler.key 2048
+openssl genrsa -out kube-scheduler.key 2048
 
-  openssl req -new -key kube-scheduler.key \
-    -subj "/CN=system:kube-scheduler/O=system:kube-scheduler" -out kube-scheduler.csr
+openssl req -new -key kube-scheduler.key \
+  -subj "/CN=system:kube-scheduler/O=system:kube-scheduler" -out kube-scheduler.csr
 
-  openssl x509 -req -in kube-scheduler.csr -CA ca.crt -CAkey ca.key -CAcreateserial  -out kube-scheduler.crt -days 1000
-}
+openssl x509 -req -in kube-scheduler.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-scheduler.crt -days 1000
 ```
 
 Results:
@@ -189,7 +180,7 @@ kube-scheduler.key
 kube-scheduler.crt
 ```
 
-### The Kubernetes API Server Certificate
+### The Kubernetes API server certificate
 
 The kube-apiserver certificate requires all names that various components may reach it to be part of the alternate names. These include the different DNS names, and IP addresses such as the master servers IP address, the load balancers IP address, the kube-api service IP address etc.
 
@@ -223,15 +214,13 @@ EOF
 Generate certs for kube-apiserver
 
 ```bash
-{
-  openssl genrsa -out kube-apiserver.key 2048
+openssl genrsa -out kube-apiserver.key 2048
 
-  openssl req -new -key kube-apiserver.key \
-    -subj "/CN=kube-apiserver/O=Kubernetes" -out kube-apiserver.csr -config openssl.cnf
+openssl req -new -key kube-apiserver.key \
+  -subj "/CN=kube-apiserver/O=Kubernetes" -out kube-apiserver.csr -config openssl.cnf
 
-  openssl x509 -req -in kube-apiserver.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial  -out kube-apiserver.crt -extensions v3_req -extfile openssl.cnf -days 1000
-}
+openssl x509 -req -in kube-apiserver.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-apiserver.crt -extensions v3_req -extfile openssl.cnf -days 1000
 ```
 
 Results:
@@ -241,7 +230,7 @@ kube-apiserver.crt
 kube-apiserver.key
 ```
 
-# The Kubelet Client Certificate
+# The Kubelet client certificate
 
 This certificate is for the api server to authenticate with the kubelets when it requests information from them
 
@@ -261,15 +250,13 @@ EOF
 Generate certs for kubelet authentication
 
 ```bash
-{
-  openssl genrsa -out apiserver-kubelet-client.key 2048
+openssl genrsa -out apiserver-kubelet-client.key 2048
 
-  openssl req -new -key apiserver-kubelet-client.key \
-    -subj "/CN=kube-apiserver-kubelet-client/O=system:masters" -out apiserver-kubelet-client.csr -config openssl-kubelet.cnf
+openssl req -new -key apiserver-kubelet-client.key \
+  -subj "/CN=kube-apiserver-kubelet-client/O=system:masters" -out apiserver-kubelet-client.csr -config openssl-kubelet.cnf
 
-  openssl x509 -req -in apiserver-kubelet-client.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial  -out apiserver-kubelet-client.crt -extensions v3_req -extfile openssl-kubelet.cnf -days 1000
-}
+openssl x509 -req -in apiserver-kubelet-client.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out apiserver-kubelet-client.crt -extensions v3_req -extfile openssl-kubelet.cnf -days 1000
 ```
 
 Results:
@@ -280,7 +267,7 @@ apiserver-kubelet-client.key
 ```
 
 
-### The ETCD Server Certificate
+### The ETCD server certificate
 
 Similarly ETCD server certificate must have addresses of all the servers part of the ETCD cluster
 
@@ -306,15 +293,13 @@ EOF
 Generates certs for ETCD
 
 ```bash
-{
-  openssl genrsa -out etcd-server.key 2048
+openssl genrsa -out etcd-server.key 2048
 
-  openssl req -new -key etcd-server.key \
-    -subj "/CN=etcd-server/O=Kubernetes" -out etcd-server.csr -config openssl-etcd.cnf
+openssl req -new -key etcd-server.key \
+  -subj "/CN=etcd-server/O=Kubernetes" -out etcd-server.csr -config openssl-etcd.cnf
 
-  openssl x509 -req -in etcd-server.csr \
-    -CA ca.crt -CAkey ca.key -CAcreateserial  -out etcd-server.crt -extensions v3_req -extfile openssl-etcd.cnf -days 1000
-}
+openssl x509 -req -in etcd-server.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out etcd-server.crt -extensions v3_req -extfile openssl-etcd.cnf -days 1000
 ```
 
 Results:
@@ -324,22 +309,20 @@ etcd-server.key
 etcd-server.crt
 ```
 
-## The Service Account Key Pair
+## The Service Account key pair
 
 The Kubernetes Controller Manager leverages a key pair to generate and sign service account tokens as describe in the [managing service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/) documentation.
 
 Generate the `service-account` certificate and private key:
 
 ```bash
-{
-  openssl genrsa -out service-account.key 2048
+openssl genrsa -out service-account.key 2048
 
-  openssl req -new -key service-account.key \
-    -subj "/CN=service-accounts/O=Kubernetes" -out service-account.csr
+openssl req -new -key service-account.key \
+  -subj "/CN=service-accounts/O=Kubernetes" -out service-account.csr
 
-  openssl x509 -req -in service-account.csr \
-    -CA ca.crt -CAkey ca.key -CAcreateserial  -out service-account.crt -days 1000
-}
+openssl x509 -req -in service-account.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out service-account.crt -days 1000
 ```
 
 Results:
@@ -355,11 +338,11 @@ Run the following, and select option 1 to check all required certificates were g
 
 [//]: # (command:./cert_verify.sh 1)
 
-```
+```bash
 ./cert_verify.sh
 ```
 
-> Expected output
+Expected output:
 
 ```
 PKI generated correctly!
@@ -367,12 +350,11 @@ PKI generated correctly!
 
 If there are any errors, please review above steps and then re-verify
 
-## Distribute the Certificates
+## Distribute the certificates
 
 Copy the appropriate certificates and private keys to each instance:
 
 ```bash
-{
 for instance in master-1 master-2; do
   scp -o StrictHostKeyChecking=no ca.crt ca.key kube-apiserver.key kube-apiserver.crt \
     apiserver-kubelet-client.crt apiserver-kubelet-client.key \
@@ -386,10 +368,9 @@ done
 for instance in worker-1 worker-2 ; do
   scp ca.crt kube-proxy.crt kube-proxy.key ${instance}:~/
 done
-}
 ```
 
-## Optional - Check Certificates on master-2
+## Optional - check certificates on master-2
 
 At `master-2` node run the following, selecting option 1
 
@@ -400,4 +381,4 @@ At `master-2` node run the following, selecting option 1
 ```
 
 Prev: [Client tools](03-client-tools.md)<br>
-Next: [Generating Kubernetes Configuration Files for Authentication](05-kubernetes-configuration-files.md)
+Next: [Generating Kubernetes configuration files for authentication](05-kubernetes-configuration-files.md)

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -125,7 +125,6 @@ openssl req -new -key kube-controller-manager.key \
 
 openssl x509 -req -in kube-controller-manager.csr \
   -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-controller-manager.crt -days 1000
-}
 ```
 
 Results:
@@ -232,7 +231,7 @@ kube-apiserver.key
 
 # The Kubelet client certificate
 
-This certificate is for the api server to authenticate with the kubelets when it requests information from them
+This certificate is for the API server to authenticate with the kubelets when it requests information from them
 
 ```bash
 cat > openssl-kubelet.cnf <<EOF

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -1,4 +1,4 @@
-# Provisioning a CA and Generating TLS Certificates
+# Provisioning a CA and generating TLS certificates
 
 In this lab you will provision a [PKI Infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure) using the popular openssl tool, then use it to bootstrap a Certificate Authority, and generate TLS certificates for the following components: etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kubelet, and kube-proxy.
 
@@ -10,7 +10,7 @@ In our case we do the following steps on the `master-1` node, as we have set it 
 
 [//]: # (host:master-1)
 
-## Certificate Authority
+## Certificate authority
 
 In this section you will provision a Certificate Authority that can be used to generate additional TLS certificates.
 
@@ -24,7 +24,7 @@ MASTER_2=$(dig +short master-2)
 LOADBALANCER=$(dig +short loadbalancer)
 ```
 
-Compute cluster internal API server service address, which is always .1 in the service CIDR range. This is also required as a SAN in the API server certificate. Run the following:
+Compute cluster internal API server service address, which is always `.1` in the service CIDR range. This is also required as a SAN in the API server certificate. Run the following:
 
 ```bash
 SERVICE_CIDR=10.96.0.0/24
@@ -75,15 +75,16 @@ ca.key
 
 Reference : https://kubernetes.io/docs/tasks/administer-cluster/certificates/#openssl
 
-The ca.crt is the Kubernetes Certificate Authority certificate and ca.key is the Kubernetes Certificate Authority private key.
-You will use the ca.crt file in many places, so it will be copied to many places.
-The ca.key is used by the CA for signing certificates. And it should be securely stored. In this case our master node(s) is our CA server as well, so we will store it on master node(s). There is no need to copy this file elsewhere.
+The `ca.crt` is the Kubernetes Certificate Authority certificate and ca.key is the Kubernetes Certificate Authority private key.
+You will use the `ca.crt` file in many places, so it will be copied to many places.
 
-## Client and Server Certificates
+The `ca.key` is used by the CA for signing certificates. And it should be securely stored. In this case our master node(s) is our CA server as well, so we will store it on master node(s). There is no need to copy this file elsewhere.
+
+## Client and server certificates
 
 In this section you will generate client and server certificates for each Kubernetes component and a client certificate for the Kubernetes `admin` user.
 
-### The Admin Client Certificate
+### The admin client certificate
 
 Generate the `admin` client certificate and private key:
 
@@ -100,7 +101,7 @@ Generate the `admin` client certificate and private key:
 }
 ```
 
-Note that the admin user is part of the **system:masters** group. This is how we are able to perform any administrative operations on Kubernetes cluster using kubectl utility.
+Note that the admin user is part of the **system:masters** group. This is how we are able to perform any administrative operations on Kubernetes cluster using `kubectl` utility.
 
 Results:
 
@@ -109,14 +110,14 @@ admin.key
 admin.crt
 ```
 
-The admin.crt and admin.key file gives you administrative access. We will configure these to be used with the kubectl tool to perform administrative functions on kubernetes.
+The `admin.crt` and `admin.key` file gives you administrative access. We will configure these to be used with the `kubectl` tool to perform administrative functions on Kubernetes.
 
-### The Kubelet Client Certificates
+### The kubelet client certificates
 
 We are going to skip certificate configuration for Worker Nodes for now. We will deal with them when we configure the workers.
 For now let's just focus on the control plane components.
 
-### The Controller Manager Client Certificate
+### The controller manager client certificate
 
 Generate the `kube-controller-manager` client certificate and private key:
 

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -172,12 +172,14 @@ Generate the `kube-scheduler` client certificate and private key:
 
 
 ```bash
-openssl genrsa -out kube-scheduler.key 2048
+{
+  openssl genrsa -out kube-scheduler.key 2048
 
-openssl req -new -key kube-scheduler.key \
-  -subj "/CN=system:kube-scheduler/O=system:kube-scheduler" -out kube-scheduler.csr
+  openssl req -new -key kube-scheduler.key \
+    -subj "/CN=system:kube-scheduler/O=system:kube-scheduler" -out kube-scheduler.csr
 
-openssl x509 -req -in kube-scheduler.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-scheduler.crt -days 1000
+  openssl x509 -req -in kube-scheduler.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-scheduler.crt -days 1000
+}
 ```
 
 Results:
@@ -259,13 +261,15 @@ EOF
 Generate certs for kubelet authentication
 
 ```bash
-openssl genrsa -out apiserver-kubelet-client.key 2048
+{
+  openssl genrsa -out apiserver-kubelet-client.key 2048
 
-openssl req -new -key apiserver-kubelet-client.key \
-  -subj "/CN=kube-apiserver-kubelet-client/O=system:masters" -out apiserver-kubelet-client.csr -config openssl-kubelet.cnf
+  openssl req -new -key apiserver-kubelet-client.key \
+    -subj "/CN=kube-apiserver-kubelet-client/O=system:masters" -out apiserver-kubelet-client.csr -config openssl-kubelet.cnf
 
-openssl x509 -req -in apiserver-kubelet-client.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out apiserver-kubelet-client.crt -extensions v3_req -extfile openssl-kubelet.cnf -days 1000
+  openssl x509 -req -in apiserver-kubelet-client.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out apiserver-kubelet-client.crt -extensions v3_req -extfile openssl-kubelet.cnf -days 1000
+}
 ```
 
 Results:
@@ -327,13 +331,15 @@ The Kubernetes Controller Manager leverages a key pair to generate and sign serv
 Generate the `service-account` certificate and private key:
 
 ```bash
-openssl genrsa -out service-account.key 2048
+{
+  openssl genrsa -out service-account.key 2048
 
-openssl req -new -key service-account.key \
-  -subj "/CN=service-accounts/O=Kubernetes" -out service-account.csr
+  openssl req -new -key service-account.key \
+    -subj "/CN=service-accounts/O=Kubernetes" -out service-account.csr
 
-openssl x509 -req -in service-account.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out service-account.crt -days 1000
+  openssl x509 -req -in service-account.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out service-account.crt -days 1000
+}
 ```
 
 Results:

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -1,4 +1,4 @@
-# Provisioning a CA and generating TLS certificates
+# Provisioning a CA and Generating TLS Certificates
 
 In this lab you will provision a [PKI Infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure) using the popular openssl tool, then use it to bootstrap a Certificate Authority, and generate TLS certificates for the following components: etcd, kube-apiserver, kube-controller-manager, kube-scheduler, kubelet, and kube-proxy.
 
@@ -10,7 +10,7 @@ In our case we do the following steps on the `master-1` node, as we have set it 
 
 [//]: # (host:master-1)
 
-## Certificate authority
+## Certificate Authority
 
 In this section you will provision a Certificate Authority that can be used to generate additional TLS certificates.
 
@@ -80,11 +80,11 @@ You will use the `ca.crt` file in many places, so it will be copied to many plac
 
 The `ca.key` is used by the CA for signing certificates. And it should be securely stored. In this case our master node(s) is our CA server as well, so we will store it on master node(s). There is no need to copy this file elsewhere.
 
-## Client and server certificates
+## Client and Server Certificates
 
 In this section you will generate client and server certificates for each Kubernetes component and a client certificate for the Kubernetes `admin` user.
 
-### The admin client certificate
+### The Admin Client Certificate
 
 Generate the `admin` client certificate and private key:
 
@@ -112,12 +112,12 @@ admin.crt
 
 The `admin.crt` and `admin.key` file gives you administrative access. We will configure these to be used with the `kubectl` tool to perform administrative functions on Kubernetes.
 
-### The kubelet client certificates
+### The Kubelet Client Certificates
 
 We are going to skip certificate configuration for Worker Nodes for now. We will deal with them when we configure the workers.
 For now let's just focus on the control plane components.
 
-### The controller manager client certificate
+### The Controller Manager Client Certificate
 
 Generate the `kube-controller-manager` client certificate and private key:
 
@@ -141,7 +141,7 @@ kube-controller-manager.crt
 ```
 
 
-### The Kube Proxy client certificate
+### The Kube Proxy Client Certificate
 
 Generate the `kube-proxy` client certificate and private key:
 
@@ -165,7 +165,7 @@ kube-proxy.key
 kube-proxy.crt
 ```
 
-### The Scheduler client certificate
+### The Scheduler Client Certificate
 
 Generate the `kube-scheduler` client certificate and private key:
 
@@ -189,7 +189,7 @@ kube-scheduler.key
 kube-scheduler.crt
 ```
 
-### The Kubernetes API server certificate
+### The Kubernetes API Server Certificate
 
 The kube-apiserver certificate requires all names that various components may reach it to be part of the alternate names. These include the different DNS names, and IP addresses such as the master servers IP address, the load balancers IP address, the kube-api service IP address etc.
 
@@ -241,7 +241,7 @@ kube-apiserver.crt
 kube-apiserver.key
 ```
 
-# The Kubelet client certificate
+# The Kubelet Client Certificate
 
 This certificate is for the API server to authenticate with the kubelets when it requests information from them
 
@@ -280,7 +280,7 @@ apiserver-kubelet-client.key
 ```
 
 
-### The ETCD server certificate
+### The ETCD Server Certificate
 
 Similarly ETCD server certificate must have addresses of all the servers part of the ETCD cluster
 
@@ -324,7 +324,7 @@ etcd-server.key
 etcd-server.crt
 ```
 
-## The Service Account key pair
+## The Service Account Key Pair
 
 The Kubernetes Controller Manager leverages a key pair to generate and sign service account tokens as describe in the [managing service accounts](https://kubernetes.io/docs/admin/service-accounts-admin/) documentation.
 
@@ -367,7 +367,7 @@ PKI generated correctly!
 
 If there are any errors, please review above steps and then re-verify
 
-## Distribute the certificates
+## Distribute the Certificates
 
 Copy the appropriate certificates and private keys to each instance:
 
@@ -389,7 +389,7 @@ done
 }
 ```
 
-## Optional - check certificates on master-2
+## Optional - Check Certificates on master-2
 
 At `master-2` node run the following, selecting option 1
 
@@ -400,4 +400,4 @@ At `master-2` node run the following, selecting option 1
 ```
 
 Prev: [Client tools](03-client-tools.md)<br>
-Next: [Generating Kubernetes configuration files for authentication](05-kubernetes-configuration-files.md)
+Next: [Generating Kubernetes Configuration Files for Authentication](05-kubernetes-configuration-files.md)

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -54,14 +54,16 @@ The output should look like this. If you changed any of the defaults mentioned i
 Create a CA certificate, then generate a Certificate Signing Request and use it to create a private key:
 
 ```bash
-# Create private key for CA
-openssl genrsa -out ca.key 2048
+{
+  # Create private key for CA
+  openssl genrsa -out ca.key 2048
 
-# Create CSR using the private key
-openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA/O=Kubernetes" -out ca.csr
+  # Create CSR using the private key
+  openssl req -new -key ca.key -subj "/CN=KUBERNETES-CA/O=Kubernetes" -out ca.csr
 
-# Self sign the csr using its own private key
-openssl x509 -req -in ca.csr -signkey ca.key -CAcreateserial -out ca.crt -days 1000
+  # Self sign the csr using its own private key
+  openssl x509 -req -in ca.csr -signkey ca.key -CAcreateserial -out ca.crt -days 1000
+}
 ```
 
 Results:
@@ -87,14 +89,16 @@ In this section you will generate client and server certificates for each Kubern
 Generate the `admin` client certificate and private key:
 
 ```bash
-# Generate private key for admin user
-openssl genrsa -out admin.key 2048
+{
+  # Generate private key for admin user
+  openssl genrsa -out admin.key 2048
 
-# Generate CSR for admin user. Note the OU.
-openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
+  # Generate CSR for admin user. Note the OU.
+  openssl req -new -key admin.key -subj "/CN=admin/O=system:masters" -out admin.csr
 
-# Sign certificate for admin user using CA servers private key
-openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out admin.crt -days 1000
+  # Sign certificate for admin user using CA servers private key
+  openssl x509 -req -in admin.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out admin.crt -days 1000
+}
 ```
 
 Note that the admin user is part of the **system:masters** group. This is how we are able to perform any administrative operations on Kubernetes cluster using `kubectl` utility.
@@ -118,13 +122,15 @@ For now let's just focus on the control plane components.
 Generate the `kube-controller-manager` client certificate and private key:
 
 ```bash
-openssl genrsa -out kube-controller-manager.key 2048
+{
+  openssl genrsa -out kube-controller-manager.key 2048
 
-openssl req -new -key kube-controller-manager.key \
-  -subj "/CN=system:kube-controller-manager/O=system:kube-controller-manager" -out kube-controller-manager.csr
+  openssl req -new -key kube-controller-manager.key \
+    -subj "/CN=system:kube-controller-manager/O=system:kube-controller-manager" -out kube-controller-manager.csr
 
-openssl x509 -req -in kube-controller-manager.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-controller-manager.crt -days 1000
+  openssl x509 -req -in kube-controller-manager.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-controller-manager.crt -days 1000
+}
 ```
 
 Results:
@@ -141,13 +147,15 @@ Generate the `kube-proxy` client certificate and private key:
 
 
 ```bash
-openssl genrsa -out kube-proxy.key 2048
+{
+  openssl genrsa -out kube-proxy.key 2048
 
-openssl req -new -key kube-proxy.key \
-  -subj "/CN=system:kube-proxy/O=system:node-proxier" -out kube-proxy.csr
+  openssl req -new -key kube-proxy.key \
+    -subj "/CN=system:kube-proxy/O=system:node-proxier" -out kube-proxy.csr
 
-openssl x509 -req -in kube-proxy.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-proxy.crt -days 1000
+  openssl x509 -req -in kube-proxy.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-proxy.crt -days 1000
+}
 ```
 
 Results:
@@ -213,13 +221,15 @@ EOF
 Generate certs for kube-apiserver
 
 ```bash
-openssl genrsa -out kube-apiserver.key 2048
+{
+  openssl genrsa -out kube-apiserver.key 2048
 
-openssl req -new -key kube-apiserver.key \
-  -subj "/CN=kube-apiserver/O=Kubernetes" -out kube-apiserver.csr -config openssl.cnf
+  openssl req -new -key kube-apiserver.key \
+    -subj "/CN=kube-apiserver/O=Kubernetes" -out kube-apiserver.csr -config openssl.cnf
 
-openssl x509 -req -in kube-apiserver.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-apiserver.crt -extensions v3_req -extfile openssl.cnf -days 1000
+  openssl x509 -req -in kube-apiserver.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out kube-apiserver.crt -extensions v3_req -extfile openssl.cnf -days 1000
+}
 ```
 
 Results:
@@ -292,13 +302,15 @@ EOF
 Generates certs for ETCD
 
 ```bash
-openssl genrsa -out etcd-server.key 2048
+{
+  openssl genrsa -out etcd-server.key 2048
 
-openssl req -new -key etcd-server.key \
-  -subj "/CN=etcd-server/O=Kubernetes" -out etcd-server.csr -config openssl-etcd.cnf
+  openssl req -new -key etcd-server.key \
+    -subj "/CN=etcd-server/O=Kubernetes" -out etcd-server.csr -config openssl-etcd.cnf
 
-openssl x509 -req -in etcd-server.csr \
-  -CA ca.crt -CAkey ca.key -CAcreateserial -out etcd-server.crt -extensions v3_req -extfile openssl-etcd.cnf -days 1000
+  openssl x509 -req -in etcd-server.csr \
+    -CA ca.crt -CAkey ca.key -CAcreateserial -out etcd-server.crt -extensions v3_req -extfile openssl-etcd.cnf -days 1000
+}
 ```
 
 Results:
@@ -354,6 +366,7 @@ If there are any errors, please review above steps and then re-verify
 Copy the appropriate certificates and private keys to each instance:
 
 ```bash
+{
 for instance in master-1 master-2; do
   scp -o StrictHostKeyChecking=no ca.crt ca.key kube-apiserver.key kube-apiserver.crt \
     apiserver-kubelet-client.crt apiserver-kubelet-client.key \
@@ -367,6 +380,7 @@ done
 for instance in worker-1 worker-2 ; do
   scp ca.crt kube-proxy.crt kube-proxy.key ${instance}:~/
 done
+}
 ```
 
 ## Optional - check certificates on master-2

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -1,12 +1,12 @@
-# Generating Kubernetes Configuration Files for Authentication
+# Generating Kubernetes configuration files for authentication
 
 In this lab you will generate [Kubernetes configuration files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), also known as "kubeconfigs", which enable Kubernetes clients to locate and authenticate to the Kubernetes API Servers.
 
 Note: It is good practice to use file paths to certificates in kubeconfigs that will be used by the services. When certificates are updated, it is not necessary to regenerate the config files, as you would have to if the certificate data was embedded. Note also that the cert files don't exist in these paths yet - we will place them in later labs.
 
-User configs, like admin.kubeconfig will have the certificate info embedded within them.
+User configs, like `admin.kubeconfig` will have the certificate info embedded within them.
 
-## Client Authentication Configs
+## Client authentication configs
 
 In this section you will generate kubeconfig files for the `controller manager`, `kube-proxy`, `scheduler` clients and the `admin` user.
 
@@ -20,7 +20,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 LOADBALANCER=$(dig +short loadbalancer)
 ```
 
-### The kube-proxy Kubernetes Configuration File
+### The kube-proxy Kubernetes configuration file
 
 Generate a kubeconfig file for the `kube-proxy` service:
 

--- a/docs/05-kubernetes-configuration-files.md
+++ b/docs/05-kubernetes-configuration-files.md
@@ -1,4 +1,4 @@
-# Generating Kubernetes configuration files for authentication
+# Generating Kubernetes Configuration Files for Authentication
 
 In this lab you will generate [Kubernetes configuration files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), also known as "kubeconfigs", which enable Kubernetes clients to locate and authenticate to the Kubernetes API Servers.
 
@@ -6,7 +6,7 @@ Note: It is good practice to use file paths to certificates in kubeconfigs that 
 
 User configs, like `admin.kubeconfig` will have the certificate info embedded within them.
 
-## Client authentication configs
+## Client Authentication Configs
 
 In this section you will generate kubeconfig files for the `controller manager`, `kube-proxy`, `scheduler` clients and the `admin` user.
 
@@ -20,7 +20,7 @@ Each kubeconfig requires a Kubernetes API Server to connect to. To support high 
 LOADBALANCER=$(dig +short loadbalancer)
 ```
 
-### The kube-proxy Kubernetes configuration file
+### The kube-proxy Kubernetes Configuration File
 
 Generate a kubeconfig file for the `kube-proxy` service:
 

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -8,7 +8,7 @@ Note that in a production-ready cluster it is recommended to have an odd number 
 
 The commands in this lab up as far as the load balancer configuration must be run on each controller instance: `master-1`, and `master-2`. Login to each controller instance using SSH Terminal.
 
-You can perform this step with [tmux](01-prerequisites.md#running-commands-in-parallel-with-tmux)
+You can perform this step with [tmux](01-prerequisites.md#running-commands-in-parallel-with-tmux).
 
 ## Provision the Kubernetes Control Plane
 

--- a/docs/09-install-cri-workers.md
+++ b/docs/09-install-cri-workers.md
@@ -17,19 +17,23 @@ You can perform this step with [tmux](01-prerequisites.md#running-commands-in-pa
 Set up the Kubernetes `apt` repository
 
 ```bash
-KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }')
+{
+  KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }')
 
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+}
 ```
 
 Install `containerd` and CNI tools, first refreshing `apt` repos to get up to date versions.
 
 ```bash
-sudo apt update
-sudo apt install -y containerd kubernetes-cni kubectl ipvsadm ipset
+{
+  sudo apt update
+  sudo apt install -y containerd kubernetes-cni kubectl ipvsadm ipset
+}
 ```
 
 Set up `containerd` configuration to enable systemd Cgroups

--- a/docs/09-install-cri-workers.md
+++ b/docs/09-install-cri-workers.md
@@ -12,37 +12,31 @@ Here we will install the container runtime `containerd` from the Ubuntu distribu
 
 [//]: # (host:worker-1-worker-2)
 
-You can perform this step with [tmux](01-prerequisites.md#running-commands-in-parallel-with-tmux)
+You can perform this step with [tmux](01-prerequisites.md#running-commands-in-parallel-with-tmux).
 
 Set up the Kubernetes `apt` repository
 
 ```bash
-{
-  KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }')
+KUBE_LATEST=$(curl -L -s https://dl.k8s.io/release/stable.txt | awk 'BEGIN { FS="." } { printf "%s.%s", $1, $2 }')
 
-  sudo mkdir -p /etc/apt/keyrings
-  curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-}
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBE_LATEST}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 ```
 
 Install `containerd` and CNI tools, first refreshing `apt` repos to get up to date versions.
 
 ```bash
-{
-  sudo apt update
-  sudo apt install -y containerd kubernetes-cni kubectl ipvsadm ipset
-}
+sudo apt update
+sudo apt install -y containerd kubernetes-cni kubectl ipvsadm ipset
 ```
 
 Set up `containerd` configuration to enable systemd Cgroups
 
 ```bash
-{
-  sudo mkdir -p /etc/containerd
-  containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | sudo tee /etc/containerd/config.toml
-}
+sudo mkdir -p /etc/containerd
+containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | sudo tee /etc/containerd/config.toml
 ```
 
 Now restart `containerd` to read the new configuration

--- a/docs/09-install-cri-workers.md
+++ b/docs/09-install-cri-workers.md
@@ -39,8 +39,11 @@ Install `containerd` and CNI tools, first refreshing `apt` repos to get up to da
 Set up `containerd` configuration to enable systemd Cgroups
 
 ```bash
-sudo mkdir -p /etc/containerd
-containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | sudo tee /etc/containerd/config.toml
+{
+  sudo mkdir -p /etc/containerd
+
+  containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | sudo tee /etc/containerd/config.toml
+}
 ```
 
 Now restart `containerd` to read the new configuration

--- a/docs/10-bootstrapping-kubernetes-workers.md
+++ b/docs/10-bootstrapping-kubernetes-workers.md
@@ -66,24 +66,22 @@ Generate a kubeconfig file for the first worker node.
 
 On `master-1`:
 ```bash
-{
-  kubectl config set-cluster kubernetes-the-hard-way \
-    --certificate-authority=/var/lib/kubernetes/pki/ca.crt \
-    --server=https://${LOADBALANCER}:6443 \
-    --kubeconfig=worker-1.kubeconfig
+kubectl config set-cluster kubernetes-the-hard-way \
+  --certificate-authority=/var/lib/kubernetes/pki/ca.crt \
+  --server=https://${LOADBALANCER}:6443 \
+  --kubeconfig=worker-1.kubeconfig
 
-  kubectl config set-credentials system:node:worker-1 \
-    --client-certificate=/var/lib/kubernetes/pki/worker-1.crt \
-    --client-key=/var/lib/kubernetes/pki/worker-1.key \
-    --kubeconfig=worker-1.kubeconfig
+kubectl config set-credentials system:node:worker-1 \
+  --client-certificate=/var/lib/kubernetes/pki/worker-1.crt \
+  --client-key=/var/lib/kubernetes/pki/worker-1.key \
+  --kubeconfig=worker-1.kubeconfig
 
-  kubectl config set-context default \
-    --cluster=kubernetes-the-hard-way \
-    --user=system:node:worker-1 \
-    --kubeconfig=worker-1.kubeconfig
+kubectl config set-context default \
+  --cluster=kubernetes-the-hard-way \
+  --user=system:node:worker-1 \
+  --kubeconfig=worker-1.kubeconfig
 
-  kubectl config use-context default --kubeconfig=worker-1.kubeconfig
-}
+kubectl config use-context default --kubeconfig=worker-1.kubeconfig
 ```
 
 Results:
@@ -100,7 +98,7 @@ scp ca.crt worker-1.crt worker-1.key worker-1.kubeconfig worker-1:~/
 ```
 
 
-### Download and Install Worker Binaries
+### Download and install worker binaries
 
 All the following commands from here until the [verification](#verification) step must be run on `worker-1`
 
@@ -130,13 +128,12 @@ sudo mkdir -p \
 Install the worker binaries:
 
 ```bash
-{
-  chmod +x kube-proxy kubelet
-  sudo mv kube-proxy kubelet /usr/local/bin/
-}
+chmod +x kube-proxy kubelet
+sudo mv kube-proxy kubelet /usr/local/bin/
 ```
 
 ### Configure the Kubelet
+
 On worker-1:
 
 Copy keys and config to correct directories and secure
@@ -222,7 +219,8 @@ WantedBy=multi-user.target
 EOF
 ```
 
-### Configure the Kubernetes Proxy
+### Configure the Kubernetes proxy
+
 On worker-1:
 
 ```bash
@@ -263,7 +261,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-## Optional - Check Certificates and kubeconfigs
+## Optional - check certificates and kubeconfigs
 
 At `worker-1` node, run the following, selecting option 4
 
@@ -274,14 +272,13 @@ At `worker-1` node, run the following, selecting option 4
 ```
 
 
-### Start the Worker Services
+### Start the worker services
+
 On worker-1:
 ```bash
-{
-  sudo systemctl daemon-reload
-  sudo systemctl enable kubelet kube-proxy
-  sudo systemctl start kubelet kube-proxy
-}
+sudo systemctl daemon-reload
+sudo systemctl enable kubelet kube-proxy
+sudo systemctl start kubelet kube-proxy
 ```
 
 > Remember to run the above commands on worker node: `worker-1`

--- a/docs/10-bootstrapping-kubernetes-workers.md
+++ b/docs/10-bootstrapping-kubernetes-workers.md
@@ -100,7 +100,7 @@ scp ca.crt worker-1.crt worker-1.key worker-1.kubeconfig worker-1:~/
 ```
 
 
-### Download and install worker binaries
+### Download and Install Worker Binaries
 
 All the following commands from here until the [verification](#verification) step must be run on `worker-1`
 
@@ -223,7 +223,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-### Configure the Kubernetes proxy
+### Configure the Kubernetes Proxy
 
 On worker-1:
 
@@ -265,7 +265,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-## Optional - check certificates and kubeconfigs
+## Optional - Check Certificates and kubeconfigs
 
 At `worker-1` node, run the following, selecting option 4
 
@@ -276,7 +276,7 @@ At `worker-1` node, run the following, selecting option 4
 ```
 
 
-### Start the worker services
+### Start the Worker Services
 
 On worker-1:
 ```bash

--- a/docs/10-bootstrapping-kubernetes-workers.md
+++ b/docs/10-bootstrapping-kubernetes-workers.md
@@ -66,22 +66,24 @@ Generate a kubeconfig file for the first worker node.
 
 On `master-1`:
 ```bash
-kubectl config set-cluster kubernetes-the-hard-way \
-  --certificate-authority=/var/lib/kubernetes/pki/ca.crt \
-  --server=https://${LOADBALANCER}:6443 \
-  --kubeconfig=worker-1.kubeconfig
+{
+  kubectl config set-cluster kubernetes-the-hard-way \
+    --certificate-authority=/var/lib/kubernetes/pki/ca.crt \
+    --server=https://${LOADBALANCER}:6443 \
+    --kubeconfig=worker-1.kubeconfig
 
-kubectl config set-credentials system:node:worker-1 \
-  --client-certificate=/var/lib/kubernetes/pki/worker-1.crt \
-  --client-key=/var/lib/kubernetes/pki/worker-1.key \
-  --kubeconfig=worker-1.kubeconfig
+  kubectl config set-credentials system:node:worker-1 \
+    --client-certificate=/var/lib/kubernetes/pki/worker-1.crt \
+    --client-key=/var/lib/kubernetes/pki/worker-1.key \
+    --kubeconfig=worker-1.kubeconfig
 
-kubectl config set-context default \
-  --cluster=kubernetes-the-hard-way \
-  --user=system:node:worker-1 \
-  --kubeconfig=worker-1.kubeconfig
+  kubectl config set-context default \
+    --cluster=kubernetes-the-hard-way \
+    --user=system:node:worker-1 \
+    --kubeconfig=worker-1.kubeconfig
 
-kubectl config use-context default --kubeconfig=worker-1.kubeconfig
+  kubectl config use-context default --kubeconfig=worker-1.kubeconfig
+}
 ```
 
 Results:
@@ -128,8 +130,10 @@ sudo mkdir -p \
 Install the worker binaries:
 
 ```bash
-chmod +x kube-proxy kubelet
-sudo mv kube-proxy kubelet /usr/local/bin/
+{
+  chmod +x kube-proxy kubelet
+  sudo mv kube-proxy kubelet /usr/local/bin/
+}
 ```
 
 ### Configure the Kubelet
@@ -276,9 +280,11 @@ At `worker-1` node, run the following, selecting option 4
 
 On worker-1:
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable kubelet kube-proxy
-sudo systemctl start kubelet kube-proxy
+{
+  sudo systemctl daemon-reload
+  sudo systemctl enable kubelet kube-proxy
+  sudo systemctl start kubelet kube-proxy
+}
 ```
 
 > Remember to run the above commands on worker node: `worker-1`

--- a/docs/differences-to-original.md
+++ b/docs/differences-to-original.md
@@ -1,21 +1,11 @@
 # Differences between original and this solution
 
-Platform: I use VirtualBox to setup a local cluster, the original one uses GCP
-
-Nodes: 2 Master and 2 Worker vs 2 Master and 3 Worker nodes
-
-Configure 1 worker node normally
-and the second one with TLS bootstrap
-
-Node Names: I use worker-1 worker-2 instead of worker-0 worker-1
-
-IP Addresses: I use statically assigned IPs on private network
-
-Certificate File Names: I use <name>.crt for public certificate and <name>.key for private key file. Whereas original one uses <name>-.pem for certificate and <name>-key.pem for private key.
-
-I generate separate certificates for etcd-server instead of using kube-apiserver
-
-Network:
-We use weavenet
-
-Add E2E Tests
+* Platform: I use VirtualBox to setup a local cluster, the original one uses GCP.
+* Nodes: 2 master and 2 worker vs 2 master and 3 worker nodes.
+* Configure 1 worker node normally and the second one with TLS bootstrap.
+* Node names: I use worker-1 worker-2 instead of worker-0 worker-1.
+* IP Addresses: I use statically assigned IPs on private network.
+* Certificate file names: I use \<name\>.crt for public certificate and \<name\>.key for private key file. Whereas original one uses \<name\>-.pem for certificate and \<name\>-key.pem for private key.
+* I generate separate certificates for etcd-server instead of using kube-apiserver.
+* Network: we use weavenet.
+* Add E2E Tests.

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -4,10 +4,10 @@ This directory contains the configuration for the virtual machines we will use f
 
 A few prerequisites are handled by the VM provisioning steps.
 
-## Kernel Settings
+## Kernel settings
 
 1. Disable cgroups v2. I found that Kubernetes currently doesn't play nice with cgroups v2, therefore we need to set a kernel boot parameter in grub to switch back to v1.
-1. Install the `br_netfilter` kernel module that permits kube-proxy to manipulate IP tables rules
+1. Install the `br_netfilter` kernel module that permits kube-proxy to manipulate IP tables rules.
 1. Add the two tunables `net.bridge.bridge-nf-call-iptables=1` and `net.ipv4.ip_forward=1` also required for successful pod networking.
 
 ## DNS settings

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -4,7 +4,7 @@ This directory contains the configuration for the virtual machines we will use f
 
 A few prerequisites are handled by the VM provisioning steps.
 
-## Kernel settings
+## Kernel Settings
 
 1. Disable cgroups v2. I found that Kubernetes currently doesn't play nice with cgroups v2, therefore we need to set a kernel boot parameter in grub to switch back to v1.
 1. Install the `br_netfilter` kernel module that permits kube-proxy to manipulate IP tables rules.


### PR DESCRIPTION
Adjust markdown formatting:

* Remove extra capitalization.
* Remove extra curly braces \{\} inside Bash code blocks.
* Use in-line code block \`\` for IP-addresses, file names and commands.
* Add a dot at the end of sentences.
* Use Markdown list in `differences-to-original.md`. Also add escaping for angle brackets \<\>.
* No logic changes were made, only formatting improvements.


This is more like test to understand should I continue to improve formatting or should I stop trying :)
Also, if it is needed, I can split it to smaller changes.