### PR TITLE
Improve SSH Password Auth setting

### DIFF
--- a/vagrant/ubuntu/ssh.sh
+++ b/vagrant/ubuntu/ssh.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 # Enable password auth in sshd so we can use ssh-copy-id
-sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+sed -i --regexp-extended 's/#?PasswordAuthentication (yes|no)/PasswordAuthentication yes/' /etc/ssh/sshd_config
+sed -i --regexp-extended 's/#?Include \/etc\/ssh\/sshd_config.d\/\*.conf/#Include \/etc\/ssh\/sshd_config.d\/\*.conf/' /etc/ssh/sshd_config
 systemctl restart sshd


### PR DESCRIPTION
* Make sure whatever it is in the script it is enabled and set to `yes`
* Remove loading from `sshd_config.d` as cloudimg adds a file after this script is run which disables password login