### PR TITLE
Improve TLS bootstrapping documentation

### DIFF
--- a/docs/11-tls-bootstrapping-kubernetes-workers.md
+++ b/docs/11-tls-bootstrapping-kubernetes-workers.md
@@ -30,7 +30,14 @@ So let's get started!
 
 **kube-apiserver** - Ensure bootstrap token based authentication is enabled on the kube-apiserver.
 
-`--enable-bootstrap-token-auth=true`
+run this command on `controlplane01` :
+```
+grep 'enable-bootstrap-token-auth=true' /etc/systemd/system/kube-apiserver.service
+```
+
+expected output : 
+
+`  --enable-bootstrap-token-auth=true \`
 
 **kube-controller-manager** - The certificate requests are signed by the kube-controller-manager ultimately. The kube-controller-manager requires the CA Certificate and Key to perform these operations.
 


### PR DESCRIPTION
This commit enhances the clarity of the TLS bootstrapping documentation.  It enables users to verify the correct configuration in their kube-apiserver.service file, whether they're double-checking their setup or ensuring no steps were missed before proceeding.