### PR TITLE
give exec permission to setup hosts script before running it on each …

### DIFF
--- a/apple-silicon/deploy-virtual-machines.sh
+++ b/apple-silicon/deploy-virtual-machines.sh
@@ -104,6 +104,7 @@ do
     multipass transfer $hostentries $node:/tmp/
     multipass transfer $SCRIPT_DIR/01-setup-hosts.sh $node:/tmp/
     multipass transfer $SCRIPT_DIR/cert_verify.sh $node:/home/ubuntu/
+    multipass exec $node -- chmod u+x /tmp/01-setup-hosts.sh
     multipass exec $node -- /tmp/01-setup-hosts.sh
 done
 


### PR DESCRIPTION

This commit fixes 'bash: line 1: /tmp/01-setup-hosts.sh: Permission denied' error which leaves provisioned nodes as not configured properly.