### PR TITLE
Update on 10-bootstrapping-kubernetes-workers.md and 11-tls-bootstrapping-kubernetes-workers.md

### DIFF
--- a/docs/10-bootstrapping-kubernetes-workers.md
+++ b/docs/10-bootstrapping-kubernetes-workers.md
@@ -215,6 +215,7 @@ ExecStart=/usr/local/bin/kubelet \\
   --config=/var/lib/kubelet/kubelet-config.yaml \\
   --kubeconfig=/var/lib/kubelet/kubelet.kubeconfig \\
   --node-ip=${PRIMARY_IP} \\
+  --fail-swap-on=false \\
   --v=2
 Restart=on-failure
 RestartSec=5

--- a/docs/11-tls-bootstrapping-kubernetes-workers.md
+++ b/docs/11-tls-bootstrapping-kubernetes-workers.md
@@ -375,6 +375,7 @@ ExecStart=/usr/local/bin/kubelet \\
   --kubeconfig=/var/lib/kubelet/kubeconfig \\
   --cert-dir=/var/lib/kubelet/pki/ \\
   --node-ip=${PRIMARY_IP} \\
+  --fail-swap-on=false \\
   --v=2
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION


added additional flag --fail-swap-on to kubelet.service for both worker nodes

```
--fail-swap-on=false
```

After starting kubelet and kubelet-proxy, it would show "no resource found" when checking in the controlplane.

checking back on the worker node

systemctl status kubelet

shows that the process is stuck looping in restarting mode. Kubelet apparently could not be run on swap memory (which I think is provisioned by default on all vagrant boxes) hence the addition of the flag.