### PR TITLE
docs: update README - ARM64 computers in original

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If that's you then check out [Google Kubernetes Engine](https://cloud.google.com
 Kubernetes The Hard Way is optimized for learning, which means taking the long route to ensure you understand each task required to bootstrap a Kubernetes cluster. Note that the cluster when built will not be accessible from your laptop browser - that isn't what this is about. If you want a more useable cluster, try [one of these](https://github.com/kodekloudhub/certified-kubernetes-administrator-course/tree/master/kubeadm-clusters).
 
 This tutorial is a modified version of the original developed by [Kelsey Hightower](https://github.com/kelseyhightower/kubernetes-the-hard-way).
-While the original one uses GCP as the platform to deploy kubernetes,  we use a hypervisor to deploy a cluster on a local machine. If you prefer the cloud version, refer to the original one [here](https://github.com/kelseyhightower/kubernetes-the-hard-way)
+While the original one uses ARM64 computers/VMs as the platform to deploy kubernetes, we use a hypervisor to deploy a cluster on a local machine. If you prefer the ARM64 computer version, refer to the original one [here](https://github.com/kelseyhightower/kubernetes-the-hard-way)
 
 The results of this tutorial should *not* be viewed as production ready, and may receive limited support from the community, but don't let that stop you from learning!<br/>Note that we are only building 2 controlplane nodes here instead of the recommended 3 that `etcd` requires to maintain quorum. This is to save on resources, and simply to show how to load balance across more than one controlplane node.
 

--- a/docs/differences-to-original.md
+++ b/docs/differences-to-original.md
@@ -1,6 +1,6 @@
 # Differences between original and this solution
 
-* Platform: I use VirtualBox to setup a local cluster, the original one uses GCP.
+* Platform: I use VirtualBox to setup a local cluster, the original one uses ARM64 computers/VMs.
 * Nodes: 2 controlplane and 2 worker vs 2 controlplane and 3 worker nodes.
 * Configure 1 worker node normally and the second one with TLS bootstrap.
 * Node names: I use node01 node02 instead of worker-0 worker-1.


### PR DESCRIPTION
A small docs update to help anyone who's new to this repo and the one it forks. They might be confused if they see a reference to GCP. The original tutorial has now been updated to use ARM64 computers, which can optionally be VMs. It makes no official endorsement of GKE or GCP at all now.