### PR TITLE
update for loop block to copy ca keys to worker nodes

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -404,7 +404,7 @@ for instance in controlplane01 controlplane02; do
 done
 
 for instance in node01 node02 ; do
-  scp ca.crt kube-proxy.crt kube-proxy.key ${instance}:~/
+  scp ca.crt ca.key kube-proxy.crt kube-proxy.key ${instance}:~/
 done
 }
 ```

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -285,7 +285,7 @@ CONTROL02=$(dig +short controlplane02)
 LOADBALANCER=$(dig +short loadbalancer)
 ```
 
-Create HAProxy configuration to listen on API server port on this host and distribute requests evently to the two controlplane nodes.
+Create HAProxy configuration to listen on API server port on this host and distribute requests evenly to the two controlplane nodes.
 
 We configure it to operate as a [layer 4](https://en.wikipedia.org/wiki/Transport_layer) loadbalancer (using `mode tcp`), which means it forwards any traffic directly to the backends without doing anything like [SSL offloading](https://ssl2buy.com/wiki/ssl-offloading).
 


### PR DESCRIPTION
This PR address and solves the problem faced in `Bootstrapping the kubernetes worker nodes` stage.
Error Below:

vagrant@node01:~$ openssl x509 -req -in node01.csr -CA ca.crt -CAkey ca.key -CAcreateserial  -out node01.crt -extensions v3_req -extfile openssl-node01.cnf -days 1000

Certificate request self-signature ok
subject=CN = system:node:node01, O = system:nodes

Could not open file or uri for loading CA private key from ca.key
40C7A8AC257F0000:error:16000069:STORE routines:ossl_store_get0_loader_int:unregistered scheme:../crypto/store/store_register.c:237:scheme=file
40C7A8AC257F0000:error:80000002:system library:file_open:No such file or directory:../providers/implementations/storemgmt/file_store.c:267:calling stat(ca.key)

Image: 
![image](https://github.com/user-attachments/assets/5e8cb5c7-550a-4dce-9e0d-cf95ed9a6366)
