### PR TITLE
fix(kubeserver-api): unable to read client-cert /home/vagrant/admin.c…

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -400,6 +400,7 @@ for instance in controlplane01 controlplane02; do
     etcd-server.key etcd-server.crt \
     kube-controller-manager.key kube-controller-manager.crt \
     kube-scheduler.key kube-scheduler.crt \
+    admin.crt admin.key \
     ${instance}:~/
 done
 


### PR DESCRIPTION
I have copied the `admin.key` and `admin.crt` files to controlplane02 to prevent authentication errors when using the kubectl tool from the secondary node.

```bash
vagrant@controlplane02:~$ kubectl get pods
Error in configuration:
* unable to read client-cert /home/vagrant/admin.crt for admin due to open /home/vagrant/admin.crt: no such file or directory
* unable to read client-key /home/vagrant/admin.key for admin due to open /home/vagrant/admin.key: no such file or directory
```